### PR TITLE
add namespace to package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mcp-opencage-server",
-  "version": "1.0.0",
+  "name": "@opencage/mcp-opencage-server",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mcp-opencage-server",
-      "version": "1.0.0",
+      "name": "@opencage/mcp-opencage-server",
+      "version": "1.0.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mcp-opencage-server",
-  "version": "1.0.0",
+  "name": "@opencage/mcp-opencage-server",
+  "version": "1.0.1",
   "description": "MCP server for OpenCage geocoding API",
   "author": {
     "name": "OpenCage GmbH",


### PR DESCRIPTION
Add namespace to the package name. The package is meant as example and not to be published to internal or external package repositories (e.g. npm.org). Still we got a false-positive security report that this project is vulnerable to that. It is not. Adding the namespace will hopefully avoid future false-positive reports.